### PR TITLE
ANDROID-14 - setup retrofit library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,6 +118,16 @@ android {
     androidExtensions {
         experimental = true
     }
+
+    // needed after adding retrofit + gson retrofit converter -- probably some conflict with firebase
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -189,4 +189,8 @@ dependencies {
     //Lottie
     implementation 'com.airbnb.android:lottie:3.4.0'
 
+    // retrofit
+    def retrofitVersion = "2.8.1"
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -203,4 +203,7 @@ dependencies {
     def retrofitVersion = "2.8.1"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+
+    // retrofit debugging
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.2.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name="ro.wethecitizens.firstcontact.TracerApp"
         android:allowBackup="false"

--- a/app/src/main/java/ro/wethecitizens/firstcontact/server/BackendMethods.kt
+++ b/app/src/main/java/ro/wethecitizens/firstcontact/server/BackendMethods.kt
@@ -1,0 +1,14 @@
+package ro.wethecitizens.firstcontact.server
+
+import retrofit2.Call
+import retrofit2.http.GET
+
+/**
+ * Targets [RetrofitInstance.getServerUrl] endpoint.
+ */
+interface BackendMethods {
+
+    // FIXME: Delete after using actual method
+    @GET("/photos")
+    fun getAllPhotos(): Call<List<DummyPhotoModel>>
+}

--- a/app/src/main/java/ro/wethecitizens/firstcontact/server/BackendMethods.kt
+++ b/app/src/main/java/ro/wethecitizens/firstcontact/server/BackendMethods.kt
@@ -1,14 +1,30 @@
 package ro.wethecitizens.firstcontact.server
 
+import androidx.annotation.WorkerThread
 import retrofit2.Call
 import retrofit2.http.GET
 
 /**
- * Targets [RetrofitInstance.getServerUrl] endpoint.
+ * Use [getInstance] to target [RetrofitInstance.getServerUrl] endpoint.
  */
 interface BackendMethods {
 
     // FIXME: Delete after using actual method
     @GET("/photos")
+    @WorkerThread
     fun getAllPhotos(): Call<List<DummyPhotoModel>>
+
+    companion object {
+        private lateinit var instance: BackendMethods
+
+        internal fun getInstance(): BackendMethods = if (::instance.isInitialized.not()) {
+            synchronized(this) {
+                if (::instance.isInitialized.not()) {
+                    RetrofitInstance.getInstance()
+                        .create(BackendMethods::class.java)
+                        .apply { instance = this }
+                } else instance
+            }
+        } else instance
+    }
 }

--- a/app/src/main/java/ro/wethecitizens/firstcontact/server/DummyPhotoModel.kt
+++ b/app/src/main/java/ro/wethecitizens/firstcontact/server/DummyPhotoModel.kt
@@ -1,0 +1,12 @@
+package ro.wethecitizens.firstcontact.server
+
+import com.google.gson.annotations.SerializedName
+
+// FIXME: Delete after using actual method
+data class DummyPhotoModel(
+    @SerializedName("albumId") val albumId: Int,
+    @SerializedName("id") val id: Int,
+    @SerializedName("title") val title: String,
+    @SerializedName("url") val url: String,
+    @SerializedName("thumbnailUrl") val thumbnailUrl: String
+)

--- a/app/src/main/java/ro/wethecitizens/firstcontact/server/RetrofitInstance.kt
+++ b/app/src/main/java/ro/wethecitizens/firstcontact/server/RetrofitInstance.kt
@@ -11,7 +11,7 @@ internal class RetrofitInstance private constructor() {
         // FIXME: change with actual server endpoint
         private fun getServerUrl() : String = "https://jsonplaceholder.typicode.com/"
 
-        fun getInstance(): Retrofit = if (::client.isInitialized.not()) {
+        internal fun getInstance(): Retrofit = if (::client.isInitialized.not()) {
             synchronized(this) {
                 if (::client.isInitialized.not()) {
                     Retrofit.Builder()

--- a/app/src/main/java/ro/wethecitizens/firstcontact/server/RetrofitInstance.kt
+++ b/app/src/main/java/ro/wethecitizens/firstcontact/server/RetrofitInstance.kt
@@ -1,0 +1,27 @@
+package ro.wethecitizens.firstcontact.server
+
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+internal class RetrofitInstance private constructor() {
+
+    companion object {
+        private lateinit var client: Retrofit
+
+        // FIXME: change with actual server endpoint
+        private fun getServerUrl() : String = "https://jsonplaceholder.typicode.com/"
+
+        fun getInstance(): Retrofit = if (::client.isInitialized.not()) {
+            synchronized(this) {
+                if (::client.isInitialized.not()) {
+                    Retrofit.Builder()
+                        .baseUrl(getServerUrl())
+                        .addConverterFactory(GsonConverterFactory.create())
+                        .build()
+                        .apply { client = this }
+                }
+                else client
+            }
+        } else client
+    }
+}

--- a/app/src/main/java/ro/wethecitizens/firstcontact/server/RetrofitInstance.kt
+++ b/app/src/main/java/ro/wethecitizens/firstcontact/server/RetrofitInstance.kt
@@ -1,7 +1,10 @@
 package ro.wethecitizens.firstcontact.server
 
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import ro.wethecitizens.firstcontact.BuildConfig
 
 internal class RetrofitInstance private constructor() {
 
@@ -9,7 +12,7 @@ internal class RetrofitInstance private constructor() {
         private lateinit var client: Retrofit
 
         // FIXME: change with actual server endpoint
-        private fun getServerUrl() : String = "https://jsonplaceholder.typicode.com/"
+        private fun getServerUrl(): String = "https://jsonplaceholder.typicode.com/"
 
         internal fun getInstance(): Retrofit = if (::client.isInitialized.not()) {
             synchronized(this) {
@@ -17,10 +20,21 @@ internal class RetrofitInstance private constructor() {
                     Retrofit.Builder()
                         .baseUrl(getServerUrl())
                         .addConverterFactory(GsonConverterFactory.create())
+
+                        .also { builder ->
+                            // debug logging -- filter by "OkHttp"
+                            if (BuildConfig.DEBUG) {
+                                val interceptor = HttpLoggingInterceptor()
+                                interceptor.level = HttpLoggingInterceptor.Level.BODY
+                                val client =
+                                    OkHttpClient.Builder().addInterceptor(interceptor).build()
+
+                                builder.client(client)
+                            }
+                        }
                         .build()
                         .apply { client = this }
-                }
-                else client
+                } else client
             }
         } else client
     }


### PR DESCRIPTION
Added retrofit dependencies and a base structure for future server requests.

1. Inside `BackendMethods` add your REST method `newMethod` which will return `Call<NewServerResponseModel>`. 
2. Implement data class `NewServerResponseModel` with `SerializedName` values that you want to use from the server response.
3. Use new method in background thread via `BackendMethods.getInstance().newMethod`

for debug, filter `OkHttp` in Logcat to see your request response.