### PR TITLE
Android-10 - scan qr code in android app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,6 +118,16 @@ android {
     androidExtensions {
         experimental = true
     }
+
+    // needed after adding retrofit + gson retrofit converter -- probably some conflict with firebase
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -199,4 +199,7 @@ dependencies {
     //Lottie
     implementation 'com.airbnb.android:lottie:3.4.0'
 
+    // qr code scanner
+    implementation('com.journeyapps:zxing-android-embedded:4.1.0') { transitive = false }
+    implementation 'com.google.zxing:core:3.3.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="ro.wethecitizens.firstcontact">
 
     <uses-feature
@@ -16,6 +17,8 @@
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
+
     <application
         android:name="ro.wethecitizens.firstcontact.TracerApp"
         android:allowBackup="false"
@@ -24,6 +27,11 @@
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar">
+
+        <activity
+            android:name="com.journeyapps.barcodescanner.CaptureActivity"
+            android:screenOrientation="portrait"
+            tools:replace="screenOrientation" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/ro/wethecitizens/firstcontact/camera/QrScanner.kt
+++ b/app/src/main/java/ro/wethecitizens/firstcontact/camera/QrScanner.kt
@@ -1,0 +1,44 @@
+package ro.wethecitizens.firstcontact.camera
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.google.zxing.integration.android.IntentIntegrator
+import ro.wethecitizens.firstcontact.R
+
+/**
+ * Catch camera response by overriding [AppCompatActivity.onActivityResult] and calling
+ * [IntentIntegrator.parseActivityResult] when request code is [IntentIntegrator.REQUEST_CODE].
+ */
+fun startScanner(activity: AppCompatActivity) {
+    val intent = IntentIntegrator(activity)
+
+    prepareIntent(intent, activity.baseContext)
+
+    intent.initiateScan()
+}
+
+/**
+ * Catch camera response by overriding [Fragment.onActivityResult] and calling
+ * [IntentIntegrator.parseActivityResult] when request code is [IntentIntegrator.REQUEST_CODE].
+ *
+ * Make sure that the activity is passing the result to the fragment by calling [super.onActivityResult]
+ * inside [AppCompatActivity.onActivityResult]. Otherwise listen inside activity.
+ */
+fun startScanner(fragment: Fragment) {
+    val intent = IntentIntegrator.forSupportFragment(fragment)
+
+    prepareIntent(intent, fragment.requireContext())
+
+    intent.initiateScan()
+}
+
+private fun prepareIntent(intent: IntentIntegrator, context: Context) {
+    intent.apply {
+//        setDesiredBarcodeFormats() // FIXME: change when type is known
+        setPrompt(context.getString(R.string.camera_scan_message)) // FIXME: change text
+        setCameraId(0) // FIXME: check back camera
+        setBeepEnabled(false)
+        setBarcodeImageEnabled(false)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,4 +88,7 @@
     <string name="service_not_ok_action">Check app now</string>
 
     <string name="share_message">Join me in stopping the spread of COVID-19! Download OpenTrace. Go to: https://bluetrace.io</string>
+
+    <!-- custom strings -->
+    <string name="camera_scan_message">Scanati codul de pe foaia primita de la personalul medical.</string>
 </resources>


### PR DESCRIPTION
Added zxing core from https://github.com/journeyapps/zxing-android-embedded#older-sdk-versions

Usage:
1. From activity, override `onActivityResult` and call `IntentIntegrator.parseActivityResult(requestCode, resultCode, intent)` if requestCode is `IntentIntegrator.REQUEST_CODE`, then call `startScanner(activity)` to trigger scan activity.
2. From fragment, same steps, but use `startScanner(fragment)`. If the fragment's activity is overriding `onActivityRequest`, make sure to call `super.onActivityRequest` inside the activity to receive `onActivityRequest` inside fragment as well.